### PR TITLE
Use https link for resources.download.minecraft.net

### DIFF
--- a/builder/client.nix
+++ b/builder/client.nix
@@ -38,7 +38,7 @@ let
           let
             asset = fetchurl {
               sha1 = a.hash;
-              url = "http://resources.download.minecraft.net/" + hashTwo;
+              url = "https://resources.download.minecraft.net/" + hashTwo;
             };
             hashTwo = builtins.substring 0 2 a.hash + "/" + a.hash;
           in ''


### PR DESCRIPTION
I encountered this 400 response. By using https the issue disappeared.

url: 
<http://resources.download.minecraft.net/04/04e72237ecdc6189492ba0f7ac51b8d2bb04feea>.
```xml
<Error>
  <Code>AccountRequiresHttps</Code>
  <Message>
    The account being accessed does not support http. RequestId:544844ff-601e-0007-6d87-472a5c000000 Time:2023-02-23T13:03:36.8462604Z
  </Message>
  <AccountName>resourcesdownloadminecra</AccountName>
</Error>
```