### PR TITLE
Add missing auth dependency cryptography

### DIFF
--- a/module/client.nix
+++ b/module/client.nix
@@ -22,7 +22,7 @@ let
     };
 
   auth = writePython3 "checkAuth" {
-    libraries = with pkgs.python3Packages; [ requests pyjwt colorama ];
+    libraries = with pkgs.python3Packages; [ requests pyjwt colorama cryptography ];
     flakeIgnore = [ "E501" "E402" "W391" ];
   } ''
     ${builtins.replaceStrings [ "@CLIENT_ID@" ] [ config.authClientID ]


### PR DESCRIPTION
Issue:

```
To sign in, use a web browser to open the page https://www.microsoft.com/link and enter the code XXXXXXXX to authenticate.
Waiting for authentication...
Logging in as an Xbox user.
Getting authorization to access Xbox services.
Getting authorization to access Mojang services.
Determining game ownership.
Authentication Failed: InvalidAlgorithmError: Algorithm not supported.
Refused to launch game.
```

Traceback and exception:

```
Traceback (most recent call last):
  File "/nix/store/gvdy96062dkdra6bq9zpzxy994dkgs1p-python3-3.10.9-env/lib/python3.10/site-packages/jwt/api_jws.py", line 88, in get_algorithm_by_name
    return self._algorithms[alg_name]
KeyError: 'RS256'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/nix/store/gvdy96062dkdra6bq9zpzxy994dkgs1p-python3-3.10.9-env/lib/python3.10/site-packages/jwt/api_jws.py", line 295, in _verify_signature
    alg_obj = self.get_algorithm_by_name(alg)
  File "/nix/store/gvdy96062dkdra6bq9zpzxy994dkgs1p-python3-3.10.9-env/lib/python3.10/site-packages/jwt/api_jws.py", line 91, in get_algorithm_by_name
    raise NotImplementedError(
NotImplementedError: Algorithm 'RS256' could not be found. Do you have cryptography installed?

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/nix/store/hn5h8kkpnvmqci7fsgksf65s96w0vpp1-checkAuth", line 285, in <module>
    authenticate(Path(profile_path_name))
  File "/nix/store/hn5h8kkpnvmqci7fsgksf65s96w0vpp1-checkAuth", line 273, in authenticate
    profile = login_and_get_profile()
  File "/nix/store/hn5h8kkpnvmqci7fsgksf65s96w0vpp1-checkAuth", line 229, in login_and_get_profile
    if check_ownership(mc_token):
  File "/nix/store/hn5h8kkpnvmqci7fsgksf65s96w0vpp1-checkAuth", line 193, in check_ownership
    decoded = jwt.decode(signature, MOJANG_PUBLIC_KEY, algorithms=["RS256"])
  File "/nix/store/gvdy96062dkdra6bq9zpzxy994dkgs1p-python3-3.10.9-env/lib/python3.10/site-packages/jwt/api_jwt.py", line 168, in decode
    decoded = self.decode_complete(
  File "/nix/store/gvdy96062dkdra6bq9zpzxy994dkgs1p-python3-3.10.9-env/lib/python3.10/site-packages/jwt/api_jwt.py", line 120, in decode_complete
    decoded = api_jws.decode_complete(
  File "/nix/store/gvdy96062dkdra6bq9zpzxy994dkgs1p-python3-3.10.9-env/lib/python3.10/site-packages/jwt/api_jws.py", line 202, in decode_complete
    self._verify_signature(signing_input, header, signature, key, algorithms)
  File "/nix/store/gvdy96062dkdra6bq9zpzxy994dkgs1p-python3-3.10.9-env/lib/python3.10/site-packages/jwt/api_jws.py", line 297, in _verify_signature
    raise InvalidAlgorithmError("Algorithm not supported") from e
jwt.exceptions.InvalidAlgorithmError: Algorithm not supported
```