### PR TITLE
Refactor with launch-scripts and files module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Inspired by [this thread](https://discourse.nixos.org/t/minecraft-launcher-in-pu
 $ nix run github:Ninlives/minecraft.nix#v1_18_1.vanilla.client
 ```
 
-You will be asked to login before launch the game.
+You will be asked to login before launching the game.
 Only MSA login is supported, since Microsoft has started to migrate all Mojang accounts to Microsoft accounts.
 
 ## Run Server
@@ -28,6 +28,7 @@ You may use the `withConfig` function to add extra configurations to the game:
 ```sh
 {
   description = "A simple modpack.";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   inputs.minecraft = {
     url = "github:Ninlives/minecraft.nix";
     inputs.metadata.follows = "minecraft-metadata";
@@ -35,12 +36,15 @@ You may use the `withConfig` function to add extra configurations to the game:
   inputs.minecraft-metadata.url = "github:Ninlives/minecraft.json";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, minecraft, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system: {
+  outputs = { self, nixpkgs, minecraft, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      inherit (pkgs) fetchurl;
+    in {
       packages.minecraft-with-ae2 =
         (minecraft.legacyPackages.${system}.v1_18_1.fabric.client.withConfig [{
           mods = [
-            (builtins.fetchurl {
+            (fetchurl {
               # file name must have a ".jar" suffix to be loaded by fabric
               name = "fabric-api.jar";
               url =
@@ -48,7 +52,7 @@ You may use the `withConfig` function to add extra configurations to the game:
               sha256 =
                 "sha256:0d6dw9lsryy51by9iypcg2mk1p1ixf0bd3dblfgmv6nx8g98whlh";
             })
-            (builtins.fetchurl {
+            (fetchurl {
               url =
                 "https://media.forgecdn.net/files/3609/46/appliedenergistics2-10.0.0.jar";
               sha256 =
@@ -58,7 +62,7 @@ You may use the `withConfig` function to add extra configurations to the game:
           # withConfig is also composable
         }]).withConfig {
           resourcePacks = [
-            (builtins.fetchurl {
+            (fetchurl {
               url =
                 "https://media.forgecdn.net/files/3577/971/Bare+Bones+1.18.zip";
               sha256 =

--- a/all-packages.nix
+++ b/all-packages.nix
@@ -1,4 +1,5 @@
-{ pkgs ? import <nixpkgs> { }, lib ? pkgs.lib, authClientID, metadata, OS ? "linux" }:
+{ pkgs ? import <nixpkgs> { }, lib ? pkgs.lib, authClientID, metadata
+, OS ? "linux" }:
 with lib;
 let
   extendedLib = lib.extend (import ./common.nix { inherit pkgs lib metadata; });

--- a/module/client.nix
+++ b/module/client.nix
@@ -21,7 +21,7 @@ let
       readOnly = true;
     };
 in {
-  imports = [ ./common/launch-scripts.nix ./common/files.nix ];
+  imports = [ ./common/launch-script.nix ./common/files.nix ];
 
   options = {
     # Interface
@@ -87,8 +87,8 @@ in {
       recursive = !config.declarative;
     };
 
-    launch = {
-      prepare = {
+    launchScript = {
+      preparation = {
         parseRunnerArgs = {
           deps = [ "parseArgs" ];
           text = ''
@@ -135,7 +135,7 @@ in {
           '';
         };
       };
-      final = let libPath = makeLibraryPath config.libraries.preload;
+      gameExecution = let libPath = makeLibraryPath config.libraries.preload;
       in ''
         export LD_LIBRARY_PATH=${libPath}''${LD_LIBRARY_PATH:+':'}$LD_LIBRARY_PATH
         exec ${jre}/bin/java \
@@ -157,6 +157,6 @@ in {
           "''${mcargs[@]}"
       '';
     };
-    launcher = writeShellScriptBin "minecraft" config.launch.script;
+    launcher = writeShellScriptBin "minecraft" config.launchScript.finalText;
   };
 }

--- a/module/client.nix
+++ b/module/client.nix
@@ -3,9 +3,9 @@ let
   inherit (lib.types) mkOptionType listOf path package singleLineStr bool;
   inherit (lib.options) mergeEqualOption mkOption;
   inherit (lib.strings)
-    isCoercibleToString hasSuffix makeLibraryPath concatMapStringsSep
-    concatStringsSep optionalString;
-  inherit (pkgs) writeShellScript writeShellScriptBin jq jre;
+    isCoercibleToString hasSuffix makeLibraryPath concatStringsSep
+    concatMapStringsSep optionalString;
+  inherit (pkgs) writeShellScriptBin jq jre linkFarmFromDrvs;
   inherit (pkgs.writers) writePython3;
   jarPath = mkOptionType {
     name = "jarFilePath";
@@ -20,116 +20,9 @@ let
       visible = false;
       readOnly = true;
     };
-
-  auth = writePython3 "checkAuth" {
-    libraries = with pkgs.python3Packages; [ requests pyjwt colorama cryptography ];
-    flakeIgnore = [ "E501" "E402" "W391" ];
-  } ''
-    ${builtins.replaceStrings [ "@CLIENT_ID@" ] [ config.authClientID ]
-    (builtins.readFile ../auth/msa.py)}
-    ${builtins.readFile ../auth/login.py}
-  '';
-
-  runnerScript = let
-    json = "${jq}/bin/jq --raw-output";
-    libPath = makeLibraryPath config.libraries.preload;
-  in writeShellScript "minecraft" ''
-    RED='\033[0;31m'
-    FIN='\033[0m'
-    XDG_DATA_HOME="''${XDG_DATA_HOME:-~/.local/share}"
-    PROFILE="$XDG_DATA_HOME/minecraft.nix/profile.json"
-
-    mcargs=()
-    while [[ "$#" -gt 0 ]];do
-      if [[ "$1" == "--launch-profile" ]];then
-        shift 1
-        if [[ "$#" -gt 0 ]];then
-          PROFILE="$1"
-        fi
-      else
-        mcargs+=("$1")
-      fi
-      shift 1
-    done
-
-    ${auth} --profile "$PROFILE" || { echo -e "''${RED}Refused to launch game.''${FIN}"; exit 1; }
-    UUID=$(${json} '.["id"]' "$PROFILE")
-    USER_NAME=$(${json} '.["name"]' "$PROFILE")
-    ACCESS_TOKEN=$(${json} '.["mc_token"]["__value"]' "$PROFILE")
-
-    # prepare assets directory
-    mkdir -p assets
-    ln -sf ${config.assets.directory}/* assets/
-
-    export LD_LIBRARY_PATH=${libPath}''${LD_LIBRARY_PATH:+':'}$LD_LIBRARY_PATH
-    exec ${jre}/bin/java \
-      -Djava.library.path='${
-        concatMapStringsSep ":" (native: "${native}/lib")
-        config.libraries.native
-      }' \
-      -cp '${concatStringsSep ":" config.libraries.java}' \
-      ${
-        optionalString (config.mods != [ ])
-        "-Dfabric.addMods='${concatStringsSep ":" config.mods}'"
-      } \
-      ${config.mainClass} \
-      --version "${config.version}" \
-      --assetIndex "${config.assets.index}" \
-      --uuid "$UUID" \
-      --username "$USER_NAME" \
-      --accessToken "$ACCESS_TOKEN" \
-      "''${mcargs[@]}"
-  '';
-
-  launchScript = let
-    checkAndLink = src: dest: ''
-      # <<<sh>>>
-      if [[ -e "${dest}" ]];then
-        if [[ -L "${dest}" ]] && [[ "$(realpath "${dest}")" =~ ^${builtins.storeDir}/* ]];then
-          rm "${dest}"
-          ln -s "${src}" "${dest}"
-        else
-          echo "Not linking ${src} because a file with same name already exists at ${dest}."
-        fi
-      else
-        ln -s "${src}" "${dest}"
-      fi
-      # >>>sh<<<
-    '';
-    preparePacks = dir: list: ''
-      ${optionalString config.declarative ''rm -rf "${dir}"''}
-      mkdir -p "${dir}"
-      ${concatMapStringsSep "\n"
-      (p: let name = builtins.baseNameOf p; in checkAndLink p "${dir}/${name}")
-      list}
-    '';
-  in writeShellScriptBin "minecraft" ''
-    # <<<sh>>>
-    WORK_DIR="$PWD"
-    runner_args=()
-
-    while [[ "$#" -gt 0 ]];do
-      runner_args+=("$1")
-      if [[ "$1" == "--gameDir" ]];then
-        shift 1
-        runner_args+=("$1")
-        WORK_DIR="$1" 
-      fi
-      shift 1
-    done
-
-    pushd "$WORK_DIR"
-    # >>>sh<<<
-    ${preparePacks "$WORK_DIR/resourcepacks" config.resourcePacks}
-    ${preparePacks "$WORK_DIR/shaderpacks" config.shaderPacks}
-    # <<<sh>>>
-
-    ${runnerScript} "''${runner_args[@]}"
-    popd 
-    # >>>sh<<<
-  '';
-
 in {
+  imports = [ ./common/launch-scripts.nix ./common/files.nix ];
+
   options = {
     # Interface
     mods = mkOption {
@@ -183,5 +76,87 @@ in {
     version = mkInternalOption singleLineStr;
   };
 
-  config = { launcher = launchScript; };
+  config = {
+    files."assets".source = config.assets.directory;
+    files."resourcepacks" = {
+      source = linkFarmFromDrvs "resourcepacks" config.resourcePacks;
+      recursive = !config.declarative;
+    };
+    files."shaderpacks" = {
+      source = linkFarmFromDrvs "shaderpacks" config.resourcePacks;
+      recursive = !config.declarative;
+    };
+
+    launch = {
+      prepare = {
+        parseRunnerArgs = {
+          deps = [ "parseArgs" ];
+          text = ''
+            XDG_DATA_HOME="''${XDG_DATA_HOME:-~/.local/share}"
+            PROFILE="$XDG_DATA_HOME/minecraft.nix/profile.json"
+
+            mcargs=()
+            while [[ "$#" -gt 0 ]];do
+              if [[ "$1" == "--launch-profile" ]];then
+                shift 1
+                if [[ "$#" -gt 0 ]];then
+                  PROFILE="$1"
+                fi
+              else
+                mcargs+=("$1")
+              fi
+              shift 1
+            done
+          '';
+        };
+        auth = let
+          ensureAuth = writePython3 "ensureAuth" {
+            libraries = with pkgs.python3Packages; [
+              requests
+              pyjwt
+              colorama
+              cryptography
+            ];
+            flakeIgnore = [ "E501" "E402" "W391" ];
+          } ''
+            ${builtins.replaceStrings [ "@CLIENT_ID@" ] [ config.authClientID ]
+            (builtins.readFile ../auth/msa.py)}
+            ${builtins.readFile ../auth/login.py}
+          '';
+        in {
+          deps = [ "parseRunnerArgs" ];
+          text = let json = "${jq}/bin/jq --raw-output";
+          in ''
+            ${ensureAuth} --profile "$PROFILE"
+
+            UUID=$(${json} '.["id"]' "$PROFILE")
+            USER_NAME=$(${json} '.["name"]' "$PROFILE")
+            ACCESS_TOKEN=$(${json} '.["mc_token"]["__value"]' "$PROFILE")
+          '';
+        };
+      };
+      final = let libPath = makeLibraryPath config.libraries.preload;
+      in ''
+        export LD_LIBRARY_PATH=${libPath}''${LD_LIBRARY_PATH:+':'}$LD_LIBRARY_PATH
+        exec ${jre}/bin/java \
+          -Djava.library.path='${
+            concatMapStringsSep ":" (native: "${native}/lib")
+            config.libraries.native
+          }' \
+          -cp '${concatStringsSep ":" config.libraries.java}' \
+          ${
+            optionalString (config.mods != [ ])
+            "-Dfabric.addMods='${concatStringsSep ":" config.mods}'"
+          } \
+          ${config.mainClass} \
+          --version "${config.version}" \
+          --assetIndex "${config.assets.index}" \
+          --uuid "$UUID" \
+          --username "$USER_NAME" \
+          --accessToken "$ACCESS_TOKEN" \
+          "''${mcargs[@]}"
+      '';
+    };
+    launcher = writeShellScriptBin "minecraft" config.launch.script;
+  };
 }

--- a/module/common/files.nix
+++ b/module/common/files.nix
@@ -43,7 +43,7 @@ let
         type = bool;
         default = false;
         description = ''
-          Whether to link contents of the directory recursively instead of link the whole directory.
+          Whether to link contents of the directory recursively instead of linking the whole directory.
         '';
       };
     };
@@ -80,12 +80,12 @@ in {
     };
   };
   config = {
-    launch.prepare.linkFiles = {
+    launchScript.preparation.linkFiles = {
       text = ''
         ${concatMapStringsSep "\n" checkAndLink (attrValues enabledFiles)}
       '';
       deps = [ "enterWorkingDirectory" ];
     };
-    launch.path = with pkgs; [ xorg.lndir ];
+    launchScript.path = with pkgs; [ xorg.lndir ];
   };
 }

--- a/module/common/files.nix
+++ b/module/common/files.nix
@@ -1,0 +1,91 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib) mkOption filterAttrs concatMapStringsSep attrValues mkIf;
+  inherit (lib.types) attrsOf bool nullOr path str submodule;
+  inherit (pkgs) writeText;
+  fileOptions = { config, name, ... }: {
+    options = {
+      name = mkOption {
+        type = str;
+        default = name;
+        defaultText = "<name>";
+      };
+      enable = mkOption {
+        type = bool;
+        default = true;
+        description = ''
+          Wheater to link this file or directory.
+        '';
+      };
+      text = mkOption {
+        type = nullOr str;
+        default = null;
+        description = ''
+          Text of the file. If this option is null then `file.<name>.source`
+          must be set.
+        '';
+      };
+      source = mkOption {
+        type = path;
+        description = ''
+          Path to the source file or directory.
+        '';
+      };
+      target = mkOption {
+        type = str;
+        default = name;
+        defaultText = "<name>";
+        description = ''
+          Path to target file or directory.
+        '';
+      };
+      recursive = mkOption {
+        type = bool;
+        default = false;
+        description = ''
+          Whether to link contents of the directory recursively instead of link the whole directory.
+        '';
+      };
+    };
+    config = {
+      source = mkIf (config.text != null) (writeText name config.text);
+    };
+  };
+  enabledFiles = filterAttrs (name: cfg: cfg.enable) config.files;
+  link = f:
+    if f.recursive then ''
+      mkdir -p "${f.target}"
+      lndir -silent "${f.source}" "${f.target}"
+    '' else ''
+      if [[ -e "${f.target}" ]]; then
+        echo "Not linking ${f.name} because a file with same name already exists at ${f.target}."
+        false # trigger error
+      else
+        mkdir -p $(dirname "${f.target}")
+        ln -s "${f.source}" "${f.target}"
+      fi
+    '';
+  checkAndLink = f: ''
+    if [[ -L "${f.target}" ]] && [[ "$(realpath "${f.target}")" =~ ^${builtins.storeDir}/* ]]; then
+      rm "${f.target}"
+    fi
+    ${link f}
+  '';
+in {
+  options = {
+    files = mkOption {
+      type = attrsOf (submodule fileOptions);
+      description = "Set files to link into the working directory.";
+      default = { };
+    };
+  };
+  config = {
+    launch.prepare.linkFiles = {
+      text = ''
+        ${concatMapStringsSep "\n" checkAndLink (attrValues enabledFiles)}
+      '';
+      deps = [ "enterWorkingDirectory" ];
+    };
+    launch.path = with pkgs; [ xorg.lndir ];
+  };
+}

--- a/module/common/launch-scripts.nix
+++ b/module/common/launch-scripts.nix
@@ -1,0 +1,132 @@
+{ config, pkgs, lib, ... }:
+
+let
+  cfg = config.launch;
+  inherit (lib)
+    mkOption attrNames mapAttrs textClosureMap id getBin isString
+    concatMapStringsSep;
+  inherit (lib.types) attrsOf listOf str lines submodule oneOf package;
+  scriptOptions = {
+    options = {
+      deps = mkOption {
+        type = listOf str;
+        default = [ ];
+        description = "List of script dependencies.";
+      };
+      text = mkOption {
+        type = lines;
+        description = "The content of the script.";
+      };
+    };
+  };
+
+  wrapScriptSnippet = name: text: ''
+    #### Launch script snippet ${name}
+    _localstatus=0
+    printf "Run launch script snippet '%s'\n" "${name}"
+
+    ${text}
+
+    if (( _localstatus > 0 )); then
+      RED='\033[0;31m'
+      FIN='\033[0m'
+      printf "''${RED}Launch script snippet '%s' failed (%s)''${FIN}\n" "${name}" "$_localstatus"
+    fi
+  '';
+
+  wrapScriptSnippetEntry = name: entry:
+    entry // {
+      text = wrapScriptSnippet name entry.text;
+    };
+
+  mkPath = p: if isString p then p else "${getBin p}/bin";
+
+  mkLaunchScript = prepareScripts: finalScript:
+    let wrapped = mapAttrs wrapScriptSnippetEntry prepareScripts;
+    in ''
+      #!${pkgs.runtimeShell}
+
+      set -u # treat unset variables as an error when substituting
+
+      _status=0
+      trap "_status=1 _localstatus=\$?" ERR
+
+      export PATH=""
+      ${concatMapStringsSep "\n" (p: ''export PATH="${mkPath p}:$PATH"'')
+      cfg.path}
+
+      ${textClosureMap id wrapped (attrNames wrapped)}
+
+      if (( _status > 0 )); then
+        RED='\033[0;31m'
+        FIN='\033[0m'
+        echo -e "''${RED}Refused to launch game.''${FIN}";
+        exit $_status
+      fi
+
+      ${wrapScriptSnippet "final" finalScript}
+
+      # in case the final script does not perform exec
+      exit $_status
+    '';
+in {
+  options = {
+    launch = {
+      prepare = mkOption {
+        type = attrsOf (submodule scriptOptions);
+        description = "Set of prepare scripts.";
+        default = { };
+      };
+      final = mkOption {
+        type = lines;
+        description = ''
+          Final script to run. Typically `exec java`.
+
+          If errors happened in launch scripts, the final script will not be run.
+        '';
+      };
+      path = mkOption {
+        type = listOf (oneOf [ package str ]);
+        default = [ ];
+        description = ''
+          Packages added to launch script's PATH environment variable.
+          Only the bin directory will be added.
+        '';
+      };
+      script = mkOption {
+        type = lines;
+        readOnly = true;
+        default = mkLaunchScript (cfg.prepare) (cfg.final);
+        description = ''
+          Full script generated.
+        '';
+      };
+    };
+  };
+  config = {
+    # common launch scripts
+    launch.prepare = {
+      parseArgs.text = ''
+        WORK_DIR="$PWD"
+        runner_args=()
+
+        while [[ "$#" -gt 0 ]];do
+          runner_args+=("$1")
+          if [[ "$1" == "--gameDir" ]];then
+            shift 1
+            runner_args+=("$1")
+            WORK_DIR="$1"
+          fi
+          shift 1
+        done
+      '';
+      enterWorkingDirectory = {
+        deps = [ "parseArgs" ];
+        text = ''
+          cd "$WORK_DIR"
+        '';
+      };
+    };
+    launch.path = with pkgs; [ coreutils ];
+  };
+}

--- a/module/server.nix
+++ b/module/server.nix
@@ -13,7 +13,7 @@ let
     merge = mergeEqualOption;
   };
 in {
-  imports = [ ./common/launch-scripts.nix ./common/files.nix ];
+  imports = [ ./common/launch-script.nix ./common/files.nix ];
 
   options = {
     # Interface
@@ -51,7 +51,7 @@ in {
   };
 
   config = {
-    launch.final = ''
+    launchScript.gameExecution = ''
       exec ${jre}/bin/java \
         -cp '${concatStringsSep ":" config.libraries.java}' \
         ${
@@ -66,6 +66,7 @@ in {
         } \
         "''${runner_args[@]}"
     '';
-    launcher = writeShellScriptBin "minecraft-server" config.launch.script;
+    launcher =
+      writeShellScriptBin "minecraft-server" config.launchScript.finalText;
   };
 }


### PR DESCRIPTION
1. Add a new launch-scripts module in `modules/common/launch-script.nix`.

   This module includes these options:
   1. `launch.prepare.<name>.text`: prepare scripts before launching the game.
   2. `launch.prepare.<name>.deps`: prepare scripts can depend on other "prepare" scripts.
   3. `launch.final`: final script to launch the game.
   4. `launch.path`: packages added to launch script's PATH environment variable.
   5. `launch.script`: full script generated.

   The launcher config is now refactored as `launcher = writeShellScriptBin "minecraft/minecraft-server" config.launch.script`.

   The original launch logic is refactored using `launch.prepare` and `launch.final`.

2. Add a new files module in `modules/common/files.nix`.

   This module includes these options:
   1. `files.<name>.name`: just <name>
   2. `files.<name>.enable`: wheater to link this file/directory
   3. `files.<name>.text`: `null` or string, if it is not `null`, `files.<name>.source` will be set to a file containing this text
   4. `files.<name>.source`: source file/directory
   5. `files.<name>.target`: target file/directory, default to `<name>`
   6. `files.<name>.recursive`: whether to link contents of the directory recursively instead of linking the whole directory.

   This module is implemented using the launch-scripts module.

   Using this module, assets, resourcesPacks, and shaderPacks are refactored.

   ```nix
   {
     files."assets".source = config.assets.directory;
     files."resourcepacks" = {
       source = linkFarmFromDrvs "resourcepacks" config.resourcePacks;
       recursive = !config.declarative;
     };
     files."shaderpacks" = {
       source = linkFarmFromDrvs "shaderpacks" config.resourcePacks;
       recursive = !config.declarative;
     };
   }
   ```