### PR TITLE
Fix running with unset XDG_DATA_HOME and LD_LIBRARY_PATH

### DIFF
--- a/module/client.nix
+++ b/module/client.nix
@@ -92,7 +92,7 @@ in {
         parseRunnerArgs = {
           deps = [ "parseArgs" ];
           text = ''
-            XDG_DATA_HOME="''${XDG_DATA_HOME:-~/.local/share}"
+            XDG_DATA_HOME="''${XDG_DATA_HOME:-$HOME/.local/share}"
             PROFILE="$XDG_DATA_HOME/minecraft.nix/profile.json"
 
             mcargs=()
@@ -137,7 +137,7 @@ in {
       };
       gameExecution = let libPath = makeLibraryPath config.libraries.preload;
       in ''
-        export LD_LIBRARY_PATH=${libPath}''${LD_LIBRARY_PATH:+':'}$LD_LIBRARY_PATH
+        export LD_LIBRARY_PATH="${libPath}''${LD_LIBRARY_PATH:+':'}''${LD_LIBRARY_PATH:-}"
         exec ${jre}/bin/java \
           -Djava.library.path='${
             concatMapStringsSep ":" (native: "${native}/lib")


### PR DESCRIPTION
The tilde expansion necessary for XDG_DATA_HOME's previous default to take effect correctly doesn't happen in that scenario.

LD_LIBRARY_PATH being unset would previously result in failure due to `set -u`.