### PR TITLE
Proposal to make recursive linking the default for assets

### DIFF
--- a/module/client.nix
+++ b/module/client.nix
@@ -78,7 +78,10 @@ in {
   };
 
   config = {
-    files."assets".source = config.assets.directory;
+    files."assets" = {
+      source = config.assets.directory;
+      recursive = true;
+    };
     files."resourcepacks" = {
       source = linkFarmFromDrvs "resourcepacks" config.resourcePacks;
       recursive = !config.declarative;


### PR DESCRIPTION
Thank you for sharing this flake, I really like the work you've done on it!

While configuring a custom instance, I had an issue with custom skins not being downloaded. After a bit of digging, I found out that this was a known (fixed) issue in the past but that there was a major refactor since then. The refactor made the fix easy.

I was wondering if there were deliberate reasons against making this setting the default? Linking possibly hundreds of tiny asset files does feel a bit yucky, and perhaps the same outcome could be achieved more efficiently by linking the index and objects subdirectories, but I'm not a technical expert on minecraft so I'm not sure.

If this change can't be accepted, then I think at least a note in the README about this setting would be appropriate.

Kind regards