### PR TITLE
Remove --gameDir from runner_args

### DIFF
--- a/module/common/launch-script.nix
+++ b/module/common/launch-script.nix
@@ -111,13 +111,17 @@ in {
         runner_args=()
 
         while [[ "$#" -gt 0 ]];do
-          runner_args+=("$1")
-          if [[ "$1" == "--gameDir" ]];then
-            shift 1
-            runner_args+=("$1")
-            WORK_DIR="$1"
-          fi
-          shift 1
+          case "$1" in
+            --gameDir)
+              shift
+              WORK_DIR="$1"
+              shift
+              ;;
+            *)
+              runner_args+=("$1")
+              shift
+              ;;
+          esac
         done
       '';
       enterWorkingDirectory = {


### PR DESCRIPTION
Recent versions of the Minecraft server throw `UnrecognizedOptionException` with this option.

```
joptsimple.UnrecognizedOptionException: gameDir is not a recognized option
```