### PR TITLE
Replace isCoercibleToString with isStringLike

### DIFF
--- a/module/client.nix
+++ b/module/client.nix
@@ -4,14 +4,14 @@ let
   inherit (lib.types) mkOptionType listOf path package singleLineStr bool;
   inherit (lib.options) mergeEqualOption mkOption;
   inherit (lib.strings)
-    isCoercibleToString hasSuffix makeLibraryPath concatStringsSep
-    concatMapStringsSep optionalString;
+    isStringLike hasSuffix makeLibraryPath concatStringsSep concatMapStringsSep
+    optionalString;
   inherit (pkgs) writeShellScriptBin jq linkFarmFromDrvs xorg;
   inherit (pkgs.writers) writePython3;
   jarPath = mkOptionType {
     name = "jarFilePath";
     check = x:
-      isCoercibleToString x && builtins.substring 0 1 (toString x) == "/"
+      isStringLike x && builtins.substring 0 1 (toString x) == "/"
       && hasSuffix ".jar" (toString x);
     merge = mergeEqualOption;
   };

--- a/module/server.nix
+++ b/module/server.nix
@@ -2,13 +2,12 @@
 let
   inherit (lib.types) mkOptionType listOf package singleLineStr bool nullOr;
   inherit (lib.options) mergeEqualOption mkOption;
-  inherit (lib.strings)
-    isCoercibleToString hasSuffix concatStringsSep optionalString;
+  inherit (lib.strings) isStringLike hasSuffix concatStringsSep optionalString;
   inherit (pkgs) writeShellScriptBin;
   jarPath = mkOptionType {
     name = "jarFilePath";
     check = x:
-      isCoercibleToString x && builtins.substring 0 1 (toString x) == "/"
+      isStringLike x && builtins.substring 0 1 (toString x) == "/"
       && hasSuffix ".jar" (toString x);
     merge = mergeEqualOption;
   };


### PR DESCRIPTION
`isCoercibletostring` is deprecated in https://github.com/NixOS/nixpkgs/pull/208168.

Warning message: lib.strings.isCoercibleToString is deprecated in favor of either isStringLike or isConvertibleWithToString. Only use the latter if it needs to return true for null, numbers, booleans and list of similarly coercibles.