### PR TITLE
client: add missing argument --userType

### DIFF
--- a/module/client.nix
+++ b/module/client.nix
@@ -163,6 +163,7 @@ in {
           --uuid "$UUID" \
           --username "$USER_NAME" \
           --accessToken "$ACCESS_TOKEN" \
+          --userType "msa" \
           "''${mcargs[@]}"
       '';
     };


### PR DESCRIPTION
Fix chat on servers with `enforce-secure-profile=true`.

> Chat disabled due to missing profile public key. Please try reconnecting.