### PR TITLE
Auto determine java version

### DIFF
--- a/builder/client.nix
+++ b/builder/client.nix
@@ -68,6 +68,7 @@ let
     in {
       inherit authClientID;
       version = versionInfo.id;
+      java = mkDefault (defaultJavaVersion versionInfo);
       libraries.java = buildVanillaLibraries artifacts ++ [ client ];
       libraries.native = buildNativeLibraries artifacts;
       libraries.preload = preloadLibraries;

--- a/builder/server.nix
+++ b/builder/server.nix
@@ -9,6 +9,7 @@ let
     let server = fetchurl { inherit (versionInfo.downloads.server) url sha1; };
     in [{
       version = versionInfo.id;
+      java = mkDefault (defaultJavaVersion versionInfo);
       mainJar = server;
       libraries.java = [ server ];
     }];

--- a/common.nix
+++ b/common.nix
@@ -1,4 +1,7 @@
 { pkgs, lib, metadata }:
+let
+  inherit (lib) warn getExe;
+in
 self: super:
 with self; {
 
@@ -51,4 +54,18 @@ with self; {
       inherit baseModulePath buildFabricModules buildVanillaModules versionInfo
         assetsIndex fabricProfile;
     };
+
+  defaultJavaVersion = versionInfo:
+    let
+      javaMajorVersion = versionInfo.javaVersion.majorVersion or null;
+      fallback = warn ''
+        Java version is not specified by the Minecraft json file, or
+        the specified version of OpenJDK is not supported by the Nixpkgs.
+        Fallback to '${pkgs.openjdk}'.
+      '' pkgs.openjdk;
+      java = if javaMajorVersion == null
+        then fallback
+        else pkgs."openjdk${toString javaMajorVersion}" or fallback;
+    in
+      getExe java;
 }

--- a/module/common/java.nix
+++ b/module/common/java.nix
@@ -1,19 +1,6 @@
-{ config, lib, pkgs, ... }: {
+{ lib, ... }: {
   options.java = lib.mkOption {
     type = lib.types.path;
     description = "Java executable to use.";
-    default =
-      # Accroding to https://help.minecraft.net/hc/en-us/articles/4409225939853-Minecraft-Java-Edition-Installation-Issues-FAQ
-      # Java 8 is required to run Minecraft versions 1.12 through 1.17.
-      # Java 17 is required to run Minecraft version 1.18 and up.
-      if lib.versionAtLeast config.version "1.18" then
-        "${pkgs.openjdk17}/bin/java"
-      else
-        "${pkgs.openjdk8}/bin/java";
-    defaultText = ''
-      if minecraft version >= 1.18
-      then "''${openjdk17}/bin/java"
-      else "''${openjdk8}/bin/java"
-    '';
   };
 }


### PR DESCRIPTION
`v1_21.vanilla` is broken because Minecraft `1.21` requires Java 21.

```console
$ nix run github:ninlives/minecraft.nix#v1_21.vanilla.client
Run launch script snippet 'parseArgs'
Run launch script snippet 'parseRunnerArgs'
Run launch script snippet 'auth'
Successfully authenticated.
Run launch script snippet 'enterWorkingDirectory'
Run launch script snippet 'linkFiles'
Run launch script snippet 'gameExecution'
Error: LinkageError occurred while loading main class net.minecraft.client.main.Main
        java.lang.UnsupportedClassVersionError: net/minecraft/client/main/Main has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0
```

Since the Minecraft JSON file provides `javaVersion.majorVersion`, we can set the Java path based on the file.

Result:

```console
$ nix path-info .#v1_8_9.vanilla.client --recursive --derivation | grep openjdk
/nix/store/z88zslkdx3rcyl4rjylksqp6s98hmlgz-adoptopenjdk-hotspot-bin-8.0.372.drv
/nix/store/2rp7m6mpc5q6mz1wfjawd965rl2xdibp-openjdk-8u412-ga.drv
$ nix path-info .#v1_20.vanilla.client --recursive --derivation | grep openjdk
/nix/store/w560wzxxxgxvcrvlwvzl3802c058prs1-adoptopenjdk-hotspot-bin-17.0.7.drv
/nix/store/n2764w76s5crfqpkdqd1qsmvf1gha9kr-openjdk-17.0.11+9.drv
$ nix path-info .#v1_21.vanilla.client --recursive --derivation | grep openjdk
/nix/store/s6ymvqbskp57a2zdy4ygnk2kfvj3jn3s-openjdk-21+35.drv
$ nix path-info .#v13w36a.vanilla.client --recursive --derivation | grep openjdk
trace: warning: Java version is not specified by the Minecraft json file, or
the specified version of OpenJDK is not supported by the Nixpkgs.
Fallback to '/nix/store/bk3x3ia7gxqic1jgr3dz05gwi8zw671y-openjdk-21+35'.

/nix/store/s6ymvqbskp57a2zdy4ygnk2kfvj3jn3s-openjdk-21+35.drv
```