### PR TITLE
Allow inheriting the PATH environment variable from parent process

### DIFF
--- a/module/common/launch-script.nix
+++ b/module/common/launch-script.nix
@@ -4,8 +4,8 @@ let
   cfg = config.launchScript;
   inherit (lib)
     mkOption attrNames mapAttrs textClosureMap id getBin isString
-    concatMapStringsSep;
-  inherit (lib.types) attrsOf listOf str lines submodule oneOf package;
+    concatMapStringsSep optionalString;
+  inherit (lib.types) attrsOf listOf str lines submodule oneOf package bool;
   scriptOptions = {
     options = {
       deps = mkOption {
@@ -51,7 +51,7 @@ let
       _status=0
       trap "_status=1 _localstatus=\$?" ERR
 
-      export PATH=""
+      ${optionalString (!cfg.inheritPath) "export PATH="}
       ${concatMapStringsSep "\n" (p: ''export PATH="${mkPath p}:$PATH"'')
       cfg.path}
 
@@ -83,6 +83,13 @@ in {
           Script to execute the game. Typically `exec java ...`.
 
           If errors happened in launch scripts, this script will not be run.
+        '';
+      };
+      inheritPath = mkOption {
+        type = bool;
+        default = false;
+        description = ''
+          Whether to inherit the PATH environment variable from parent process.
         '';
       };
       path = mkOption {


### PR DESCRIPTION
Add a new option `launchScript.inheritPath`. 

Some functions of Minecraft, e.g., opening links in chat using browsers, or opening folders, rely on the full PATH environment variable from the user environment (since it may use `xdg-open`, and desktop files typically do not use absolute paths).

Open resource pack folder in the game raises this exception.

```console
$ mkdir /tmp/test-mc; nix run github:Ninlives/minecraft.nix#v1_21.vanilla.client -- --gameDir /tmp/test-mc
...
...
[20:57:02] [Render thread/ERROR]: Couldn't open location 'file:///tmp/test-mc/./resourcepacks/'
java.security.PrivilegedActionException: null
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:575) ~[?:?]
	at ad$a.a(SourceFile:407) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at ad$a.a(SourceFile:421) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at frt.b(SourceFile:120) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at fim.b(SourceFile:96) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at fid.a(SourceFile:48) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at fik.a(SourceFile:141) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at fkh.a(SourceFile:38) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at fgp.b(SourceFile:107) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at fod.a(SourceFile:431) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at fgp.a(SourceFile:107) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at fgp.c(SourceFile:196) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at bph.execute(SourceFile:108) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at fgp.b(SourceFile:196) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at org.lwjgl.glfw.GLFWMouseButtonCallbackI.callback(GLFWMouseButtonCallbackI.java:43) [d7sf1mi7fz40fv2a4rbsryps99v31lc6-lwjgl-glfw-3.3.3.jar:build 5]
	at org.lwjgl.system.JNI.invokeV(Native Method) ~[rcghn4r2hf0fddxzyz0mcax6kq022d11-lwjgl-3.3.3.jar:build 5]
	at org.lwjgl.glfw.GLFW.glfwPollEvents(GLFW.java:3438) [d7sf1mi7fz40fv2a4rbsryps99v31lc6-lwjgl-glfw-3.3.3.jar:build 5]
	at com.mojang.blaze3d.systems.RenderSystem.pollEvents(SourceFile:150) [iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at com.mojang.blaze3d.systems.RenderSystem.flipFrame(SourceFile:161) [iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at fam.f(SourceFile:303) [iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at fgo.c(SourceFile:1307) [iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at fgo.f(SourceFile:882) [iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at net.minecraft.client.main.Main.main(SourceFile:256) [iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
Caused by: java.io.IOException: Cannot run program "xdg-open": error=2, No such file or directory
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1170) ~[?:?]
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1089) ~[?:?]
	at java.base/java.lang.Runtime.exec(Runtime.java:681) ~[?:?]
	at java.base/java.lang.Runtime.exec(Runtime.java:530) ~[?:?]
	at ad$a.c(SourceFile:407) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:571) ~[?:?]
	... 22 more
Caused by: java.io.IOException: error=2, No such file or directory
	at java.base/java.lang.ProcessImpl.forkAndExec(Native Method) ~[?:?]
	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:295) ~[?:?]
	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:225) ~[?:?]
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1126) ~[?:?]
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1089) ~[?:?]
	at java.base/java.lang.Runtime.exec(Runtime.java:681) ~[?:?]
	at java.base/java.lang.Runtime.exec(Runtime.java:530) ~[?:?]
	at ad$a.c(SourceFile:407) ~[iam9zvpzj1f65llh6aj6zlmdav6z09ly-client.jar:?]
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:571) ~[?:?]
	... 22 more
```

Currently, I set its default value always to `false`, since it might help us find problems. We may want to set its default value to `true` for clients.
