### PR TITLE
Replace deprecated datetime.utcnow

### DIFF
--- a/auth/login.py
+++ b/auth/login.py
@@ -59,7 +59,7 @@ def authenticate(profile_path):
             error(f"{profile_path} seems to be corrupted, try to login again.")
         else:
             mc_token = profile['mc_token']
-            if mc_token.not_after < datetime.utcnow():
+            if mc_token.not_after < datetime.now(datetime.UTC):
                 refresh(profile)
                 with open(profile_path, 'w+') as f:
                     json.dump(profile, f, default=custom_encode)

--- a/auth/msa.py
+++ b/auth/msa.py
@@ -106,14 +106,14 @@ def get_ms_token() -> (Token, Token):
 
         sleep(interval)
 
-    access_token = Token(response['access_token'], datetime.utcnow() + timedelta(seconds=int(response['expires_in'])))
+    access_token = Token(response['access_token'], datetime.now(datetime.UTC) + timedelta(seconds=int(response['expires_in'])))
     refresh_token = Token(response['refresh_token'], datetime.min)
     return (access_token, refresh_token)
 
 
 def refresh_ms_token(refresh_token: Token) -> (Token, Token):
     response = post(MS_TOKEN_URL, data={'client_id': CLIENT_ID, 'refresh_token': refresh_token.value, 'grant_type': 'refresh_token'}).json()
-    access_token = Token(response['access_token'], datetime.utcnow() + timedelta(seconds=int(response['expires_in'])))
+    access_token = Token(response['access_token'], datetime.now(datetime.UTC) + timedelta(seconds=int(response['expires_in'])))
     refresh_token = Token(response['refresh_token'], datetime.min)
     return (access_token, refresh_token)
 
@@ -183,7 +183,7 @@ def get_mc_token(xsts_token: Token, user_hash: str) -> Token:
         "platform": "PC_LAUNCHER"
     }).json()
 
-    return Token(response['access_token'], datetime.utcnow() + timedelta(seconds=int(response['expires_in'])))
+    return Token(response['access_token'], datetime.now(datetime.UTC) + timedelta(seconds=int(response['expires_in'])))
 
 
 def check_ownership(mc_token: Token):
@@ -200,4 +200,3 @@ def check_ownership(mc_token: Token):
 
 def get_profile(mc_token: Token) -> Dict[str, str]:
     return get(PROFILE_URL, headers={'Authorization': f"Bearer {mc_token}"}).json()
-

--- a/module/client.nix
+++ b/module/client.nix
@@ -130,6 +130,7 @@ in {
           } ''
             ${builtins.replaceStrings [ "@CLIENT_ID@" ] [ config.authClientID ]
             (builtins.readFile ../auth/msa.py)}
+
             ${builtins.readFile ../auth/login.py}
           '';
         in {


### PR DESCRIPTION
`datetime.utcnow` has been deprecated in Python 3.12. Use `datetime.now(datetime.UTC)` instead.

<https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow>

```console
$ nix run github:ninlives/minecraft.nix#v1_21.vanilla.client -- --gameDir /tmp/test
Run launch script snippet 'parseArgs'
Run launch script snippet 'parseRunnerArgs'
Run launch script snippet 'auth'
/nix/store/9r3gn9s6lnzxh1qmz60f1hjpr4l8z4is-ensureAuth:267: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  if mc_token.not_after < datetime.utcnow():
Successfully authenticated.
...
```