### PR TITLE
Revert "replace deprecated datetime.utcnow"

### DIFF
--- a/auth/login.py
+++ b/auth/login.py
@@ -59,7 +59,7 @@ def authenticate(profile_path):
             error(f"{profile_path} seems to be corrupted, try to login again.")
         else:
             mc_token = profile['mc_token']
-            if mc_token.not_after < datetime.now(datetime.UTC):
+            if mc_token.not_after < datetime.utcnow():
                 refresh(profile)
                 with open(profile_path, 'w+') as f:
                     json.dump(profile, f, default=custom_encode)

--- a/auth/msa.py
+++ b/auth/msa.py
@@ -106,14 +106,14 @@ def get_ms_token() -> (Token, Token):
 
         sleep(interval)
 
-    access_token = Token(response['access_token'], datetime.now(datetime.UTC) + timedelta(seconds=int(response['expires_in'])))
+    access_token = Token(response['access_token'], datetime.utcnow() + timedelta(seconds=int(response['expires_in'])))
     refresh_token = Token(response['refresh_token'], datetime.min)
     return (access_token, refresh_token)
 
 
 def refresh_ms_token(refresh_token: Token) -> (Token, Token):
     response = post(MS_TOKEN_URL, data={'client_id': CLIENT_ID, 'refresh_token': refresh_token.value, 'grant_type': 'refresh_token'}).json()
-    access_token = Token(response['access_token'], datetime.now(datetime.UTC) + timedelta(seconds=int(response['expires_in'])))
+    access_token = Token(response['access_token'], datetime.utcnow() + timedelta(seconds=int(response['expires_in'])))
     refresh_token = Token(response['refresh_token'], datetime.min)
     return (access_token, refresh_token)
 
@@ -183,7 +183,7 @@ def get_mc_token(xsts_token: Token, user_hash: str) -> Token:
         "platform": "PC_LAUNCHER"
     }).json()
 
-    return Token(response['access_token'], datetime.now(datetime.UTC) + timedelta(seconds=int(response['expires_in'])))
+    return Token(response['access_token'], datetime.utcnow() + timedelta(seconds=int(response['expires_in'])))
 
 
 def check_ownership(mc_token: Token):
@@ -200,3 +200,4 @@ def check_ownership(mc_token: Token):
 
 def get_profile(mc_token: Token) -> Dict[str, str]:
     return get(PROFILE_URL, headers={'Authorization': f"Bearer {mc_token}"}).json()
+

--- a/module/client.nix
+++ b/module/client.nix
@@ -130,7 +130,6 @@ in {
           } ''
             ${builtins.replaceStrings [ "@CLIENT_ID@" ] [ config.authClientID ]
             (builtins.readFile ../auth/msa.py)}
-
             ${builtins.readFile ../auth/login.py}
           '';
         in {


### PR DESCRIPTION
Sorry, I made a silly mistake in <https://github.com/Ninlives/minecraft.nix/pull/29>...

```log
Authentication Failed: AttributeError: type object 'datetime.datetime' has no attribute 'UTC'.
Launch script snippet 'auth' failed (1)
```

Revert the PR as a quick fix.